### PR TITLE
Update XpathTest with Healed Locator

### DIFF
--- a/src/test/java/com/epam/healenium/tests/XpathTest.java
+++ b/src/test/java/com/epam/healenium/tests/XpathTest.java
@@ -18,9 +18,9 @@ public class XpathTest extends BaseTest {
         FrameworkPage page = pages.get(TEST_ENV);
 
         page.openPage()
-                .findTestElement(LocatorType.XPATH, "//*[@id='change:name']")
+                .findTestElement(LocatorType.CSS_SELECTOR, "input#newName")
                 .clickSubmitButton()
-                .findTestElement(LocatorType.XPATH, "//*[@id='change:name']");
+                .findTestElement(LocatorType.CSS_SELECTOR, "input#newName");
     }
 
     @Test


### PR DESCRIPTION
Updated the 'XpathTest.java' file to replace the broken locator `By.xpath` with the healed locator `By.cssSelector` with value `input#newName`. This change ensures that the test remains robust and reliable.